### PR TITLE
Don't let "tryrun" fill up /!

### DIFF
--- a/conf/dias.conf
+++ b/conf/dias.conf
@@ -9,7 +9,7 @@
 
 trigger_interval: '10m'
 archive_data_dir: "/mnt/gong/archive"
-task_write_dir: "/tmp"
-task_state_dir: "/tmp"
+task_write_dir: "~/dias_tmp/data"
+task_state_dir: "~/dias_tmp/state"
 prometheus_client_port: 4444
-log_level: INFO
+log_level: DEBUG

--- a/dias/config_loader.py
+++ b/dias/config_loader.py
@@ -2,7 +2,7 @@ import importlib
 import logging
 import yaml
 import os
-from dias.utils import str2timedelta
+from dias.utils import str2timedelta, str2path
 from dias import DiasConfigError, DiasUsageError, Task
 import copy
 
@@ -34,11 +34,17 @@ class ConfigLoader:
         # The default task config dir is the subdirectory "task" in
         # the directory containing dais.conf
         self._check_config_variable(
-                'task_config_dir', proptype=str,
+                'task_config_dir', proptype=str2path,
                 default=os.path.join(
                     os.path.dirname(self.config_path), "tasks"))
-        self._check_config_variable('task_write_dir', proptype=str)
-        self._check_config_variable('task_state_dir', proptype=str)
+
+        self._check_config_variable('task_write_dir', proptype=str2path)
+        self._check_config_variable('task_state_dir', proptype=str2path)
+        # now shell-expand these paths
+        self['task_config_dir'] = str2path(self['task_config_dir'])
+        self['task_write_dir'] = str2path(self['task_write_dir'])
+        self['task_state_dir'] = str2path(self['task_state_dir'])
+
         self._check_config_variable('prometheus_client_port', proptype=int)
         self._check_config_variable(
                 'log_level', default=DEFAULT_LOG_LEVEL,

--- a/dias/utils/string_converter.py
+++ b/dias/utils/string_converter.py
@@ -1,6 +1,7 @@
 # Helper functions to convert to and from strings.
 # ----------------------------------------------------------------------------
 
+import os
 import re
 from datetime import timedelta,datetime
 
@@ -64,3 +65,8 @@ def bytes2str(num):
             return "%3.1f %s" % (num, unit)
         num /= 1000.0
     return "%.1f %s" % (num, 'TB')
+
+
+# This performs shell-expansion on a string
+def str2path(s):
+    return os.path.expandvars(os.path.expanduser(s))


### PR DESCRIPTION
This moves the default temporary directories to ~/dias_tmp in the
user's home directory.  Performs path expansion magic for the paths
in the config files.