### PR TITLE
fix feedpositions metrics

### DIFF
--- a/dias/analyzers/feedpositions_analyzer.py
+++ b/dias/analyzers/feedpositions_analyzer.py
@@ -63,6 +63,10 @@ class FeedpositionsAnalyzer(CHIMEAnalyzer):
             "how many frequencies out of 10 were good (EV ratio on vs off "
             "source smaller than 2)", labelnames=['source'], unit='total')
 
+        # initialize resid source metric
+        for source in sources:
+            self.resid_metric.labels(source=source).set(0)
+
     def run(self):
 
         end_time = datetime.utcnow()


### PR DESCRIPTION
Currently this metric (`dias_task_feedpositions_ew_pos_residuals_analyzer_run`) is either `N/A` or `1`. I made it a counter instead.