### PR TITLE
doc: replace non-ASCII character

### DIFF
--- a/dias/utils/string_converter.py
+++ b/dias/utils/string_converter.py
@@ -207,7 +207,7 @@ def str2path(s):
     Returns
     -------
     str
-        The same path, but `~` or `~user` are replaced by the user’s home
+        The same path, but `~` or `~user` are replaced by the user's home
         directory and substrings of the form `$name` or `${name}` are replaced
         by the value of environment variable name. Malformed variable names and
         references to non-existing variables are left unchanged.


### PR DESCRIPTION
I now get from `python setup.py egg_info` (via `pip install`):
```
   Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-7V7haW/dias/setup.py", line 10, in <module>
        import dias
      File "dias/__init__.py", line 4, in <module>
        from .analyzer import Analyzer
      File "dias/analyzer.py", line 4, in <module>
        from dias.utils import str2timedelta, str2datetime, str2bytes
      File "dias/utils/__init__.py", line 2, in <module>
        from .string_converter import *
      File "dias/utils/string_converter.py", line 210
    SyntaxError: Non-ASCII character '\xe2' in file dias/utils/string_converter.py on line 211, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```
That non-ASCII character's been around for months.  Not sure why this hasn't happened before.