### PR TITLE
fix(setup.py): Don't import dias in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ dias, a data integrity analysis system.
 """
 
 
-import dias
 import os
 import setuptools
 import shutil


### PR DESCRIPTION
It creates a Catch-22: pip can't figure out the dependencies
because it can't run setup.py until the dependencies are installed.