### PR TITLE
fix(flag_rfi_analyzer): fixes typo log --> logger.

### DIFF
--- a/dias/analyzers/flag_rfi_analyzer.py
+++ b/dias/analyzers/flag_rfi_analyzer.py
@@ -575,8 +575,8 @@ class FlagRFIAnalyzer(chime_analyzer.CHIMEAnalyzer):
                 cursor.execute('DELETE FROM files WHERE filename = ?',
                                (filename,))
                 self.data_index.commit()
-                self.log.info("Removed %s from data index database." %
-                              filename)
+                self.logger.info("Removed %s from data index database." %
+                                 filename)
 
     def finish(self):
         """Close connection to data index database."""


### PR DESCRIPTION
flag_rfi_analyzer reached data size limit.  Dias started deleting old files,
which exercised a previously unused part of the code and encountered this
typo.