### PR TITLE
fix(flag_rfi,find_jump): save all database files in the state directory

### DIFF
--- a/conf/tasks/find_jump.conf
+++ b/conf/tasks/find_jump.conf
@@ -1,7 +1,7 @@
 analyzer: "dias.analyzers.FindJumpAnalyzer"
-archive_data_dir: "/mnt/gong/not_archived"
+archive_data_dir: "/mnt/gong/staging"
 data_size_max: '20 GB'
-state_size_max: '0 B'
+state_size_max: '100 MB'
 log_level: "INFO"
 period: '24h'
 offset: '4h'

--- a/conf/tasks/flag_rfi.conf
+++ b/conf/tasks/flag_rfi.conf
@@ -1,6 +1,6 @@
 analyzer: "dias.analyzers.FlagRFIAnalyzer"
 data_size_max: '50 GB'
-state_size_max: '0 B'
+state_size_max: '100 MB'
 offset: '2h'
 period: '2h'
 log_level: "INFO"

--- a/dias/analyzers/find_jump_analyzer.py
+++ b/dias/analyzers/find_jump_analyzer.py
@@ -554,7 +554,7 @@ class FindJumpAnalyzer(chime_analyzer.CHIMEAnalyzer):
 
         # Open connection to data index database
         # and create table if it does not exist.
-        db_file = os.path.join(self.write_dir, DB_FILE)
+        db_file = os.path.join(self.state_dir, DB_FILE)
         db_types = sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES
         self.data_index = sqlite3.connect(
             db_file, detect_types=db_types, check_same_thread=False
@@ -566,7 +566,7 @@ class FindJumpAnalyzer(chime_analyzer.CHIMEAnalyzer):
 
         # Open connection to archive index database
         # and create table if it does not exist.
-        adb_file = os.path.join(self.write_dir, ARCHIVE_DB_FILE)
+        adb_file = os.path.join(self.state_dir, ARCHIVE_DB_FILE)
         self.archive_index = sqlite3.connect(
             adb_file, detect_types=db_types, check_same_thread=False
         )

--- a/dias/analyzers/flag_rfi_analyzer.py
+++ b/dias/analyzers/flag_rfi_analyzer.py
@@ -243,7 +243,7 @@ class FlagRFIAnalyzer(chime_analyzer.CHIMEAnalyzer):
 
         # Open connection to data index database
         # and create table if it does not exist
-        db_file = os.path.join(self.write_dir, DB_FILE)
+        db_file = os.path.join(self.state_dir, DB_FILE)
         db_types = sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES
         # The connection can only be used by one thread at a time.
         # This analyzer does not serialize use of the connection.


### PR DESCRIPTION
Moves all database files for the flag_rfi_analyzer and find_jump_analyzer
from the data directory to the state directory.  Also changes the
archive_data_dir for the find_jump_analyzer from the deprecated
/mnt/gong/not_archived to /mnt/gong/staging.

Closes Issue #97 and Issue #99.