### PR TITLE
fix(thermaldata): expects a data-interval for an acquisition, not a filename

### DIFF
--- a/dias/analyzers/thermaldata_analyzer.py
+++ b/dias/analyzers/thermaldata_analyzer.py
@@ -111,7 +111,9 @@ class ThermalDataAnalyzer(CHIMEAnalyzer):
 
             # only use the first acquisition found
             first_result = results_list[0]
-            first_result_folder_datetime = re.search("(\d*T\d*)Z", first_result).groups()[0]
+            first_result_folder_datetime = re.search(
+                "(\d*T\d*)Z", first_result
+            ).groups()[0]
             first_acquisition = []
 
             # an acquisition can represent a list of files in the same 'acq' folder
@@ -119,12 +121,14 @@ class ThermalDataAnalyzer(CHIMEAnalyzer):
                 if first_result_folder_datetime in f:
                     first_acquisition.append(f)
 
-            assert len(first_acquisition) >= 1, "At this point, there should be at least 1 result"
+            assert (
+                len(first_acquisition) >= 1
+            ), "At this point, there should be at least 1 result"
 
-            read = andata.CorrReader(first_acquisition)
-            prods = read.prod
-            freq = read.freq["centre"]
-            ntimes = len(read.time)
+            reader = andata.CorrReader(first_acquisition)
+            prods = reader.prod
+            freq = reader.freq["centre"]
+            ntimes = len(reader.time)
             time_indices = np.linspace(
                 self.checkoffset, ntimes, self.nchecks, endpoint=False, dtype=int
             )
@@ -146,8 +150,7 @@ class ThermalDataAnalyzer(CHIMEAnalyzer):
                 prod_sel.append(pidx)
 
             # Load data from first acquisition
-            reader = andata.CorrReader(first_acquisition)
-            setattr(reader, 'prod_sel', np.array(prod_sel))
+            setattr(reader, "prod_sel", np.array(prod_sel))
             data = reader.read()
             phases = np.angle(data.vis)
 


### PR DESCRIPTION
Addresses

```
AlertManagerAPP 09:17
dias no data. (marimba:4444)  - WARNING
The dias task thermaldata can't find any data. If this is expected, silence this alert until there should be data again.

Anja Boskovic 10:21
Dec 16 09:13:17 marimba dias[20040]: [2019-12-16 17:13:17,140] dias[thermaldata]: Task failed: 'str' object has no attribute 'as_loaded_data'
Dec 16 09:13:17 marimba dias[20040]: [2019-12-16 17:13:17,450] dias[thermaldata]: Traceback (most recent call last):
Dec 16 09:13:17 marimba dias[20040]:   File "/usr/local/lib/python3.5/dist-packages/dias/task.py", line 229, in runner
Dec 16 09:13:17 marimba dias[20040]:     result = self.analyzer.run()
Dec 16 09:13:17 marimba dias[20040]:   File "/usr/local/lib/python3.5/dist-packages/dias/analyzers/thermaldata_analyzer.py", line 135, in run
Dec 16 09:13:17 marimba dias[20040]:     data = result.as_loaded_data(prod_sel=np.array(prod_sel))
Dec 16 09:13:17 marimba dias[20040]: AttributeError: 'str' object has no attribute 'as_loaded_data'
Dec 16 09:13:17 marimba dias[20040]: [2019-12-16 17:13:17,451] dias[thermaldata]: Cleaning up /mnt/gong/dias/data/thermaldata: data size maximum: 0.0 B
Dec 16 09:13:17 marimba dias[20040]: [2019-12-16 17:13:17,453] dias[thermaldata]: Cleaning up /mnt/gong/dias/state/thermaldata: data size maximum: 0.0 
```