### PR TITLE
fix(task): rename metric

### DIFF
--- a/dias/task.py
+++ b/dias/task.py
@@ -78,7 +78,7 @@ class Task:
         # We're only allowed to define these once, so we cache them
         if not task_metrics:
             task_metrics["data_written"] = Gauge(
-                "data_written",
+                "total_data_written",
                 "Total amount of data written, "
                 "including files deleted due to "
                 "disk space overage.",


### PR DESCRIPTION
The `dias_data_...` metric namespace is meant to be for data metrics written by analyzers, not housekeeping information.  This renames the housekeeping metric `dias_data_written_bytes` to `dias_total_data_written_bytes` to move it out of the `dias_data` namespace.