### PR TITLE
fix(find_jump): add workaround for h5py not supporting dtype <U32

### DIFF
--- a/dias/analyzers/find_jump_analyzer.py
+++ b/dias/analyzers/find_jump_analyzer.py
@@ -1117,6 +1117,13 @@ class FindJumpAnalyzer(chime_analyzer.CHIMEAnalyzer):
                     for key, val in self.output_attrs.items():
                         handler.attrs[key] = val
 
+                    # h5py cannot write dtype = <U32
+                    # HDF5 has no support for them
+                    this_input = np.array(
+                        this_input,
+                        dtype=[("chan_id", "<u2"), ("correlator_input", "<S32")],
+                    )
+
                     # Create a group that describes the data
                     # that was searched
                     srchd = handler.create_group("searched")


### PR DESCRIPTION
```
y 03 23:57:07 marimba dias[6884]:   File "/usr/local/lib/python3.7/dist-packages/dias/analyzers/find_jump_analyzer.py", line 1125, in run                                  
May 03 23:57:07 marimba dias[6884]:     srchd.create_dataset("input", data=this_input[ifeed])                                                                                
May 03 23:57:07 marimba dias[6884]:   File "/usr/local/lib/python3.7/dist-packages/h5py/_hl/group.py", line 136, in create_dataset                                           
May 03 23:57:07 marimba dias[6884]:     dsid = dataset.make_new_dset(self, shape, dtype, data, **kwds)                                                                       
May 03 23:57:07 marimba dias[6884]:   File "/usr/local/lib/python3.7/dist-packages/h5py/_hl/dataset.py", line 118, in make_new_dset                                          
May 03 23:57:07 marimba dias[6884]:     tid = h5t.py_create(dtype, logical=1)                                                                                                
May 03 23:57:07 marimba dias[6884]:   File "h5py/h5t.pyx", line 1634, in h5py.h5t.py_create                                                                                  
May 03 23:57:07 marimba dias[6884]:   File "h5py/h5t.pyx", line 1656, in h5py.h5t.py_create                                                                                  
May 03 23:57:07 marimba dias[6884]:   File "h5py/h5t.pyx", line 1678, in h5py.h5t.py_create                                                                                  
May 03 23:57:07 marimba dias[6884]:   File "h5py/h5t.pyx", line 1591, in h5py.h5t._c_compound                                                                                
May 03 23:57:07 marimba dias[6884]:   File "h5py/h5t.pyx", line 1656, in h5py.h5t.py_create                                                                                  
May 03 23:57:07 marimba dias[6884]:   File "h5py/h5t.pyx", line 1717, in h5py.h5t.py_create                                                                                  
May 03 23:57:07 marimba dias[6884]: TypeError: No conversion path for dtype: dtype('<U32')  
```

From the h5py docs:
```
What about NumPy’s U type?
NumPy also has a Unicode type, a UTF-32 fixed-width format (4-byte
characters). HDF5 has no support for wide characters. Rather than trying
to hack around this and “pretend” to support it, h5py will raise an
error when attempting to create datasets or attributes of this type.
```

Tested on live DIAS analyzer, and seems to do the trick.