### PR TITLE
fix(tracker): inserts should use a replace conflict resolution strategy

### DIFF
--- a/dias/tracker.py
+++ b/dias/tracker.py
@@ -247,7 +247,7 @@ class Tracker:
                         "end_time": source["index_map/time"][-1]["ctime"],
                         "exists": True,
                     }
-                ).execute()
+                ).on_conflict_replace().execute()
 
     def remove_files(self, files):
         """
@@ -366,4 +366,4 @@ class Tracker:
         with db:
             # SQLite limits bulk inserts to 100 at a time
             for batch in chunked(records, 100):
-                Processed.insert_many(batch).on_conflict(action="IGNORE").execute()
+                Processed.insert_many(batch).on_conflict_replace().execute()

--- a/test/test_tracker.py
+++ b/test/test_tracker.py
@@ -18,7 +18,7 @@ base_path = os.path.expanduser("~/dias_tmp")
 Path(base_path).mkdir(exist_ok=True)
 
 
-@pytest.fixture("session")
+@pytest.fixture(scope="session")
 def staging_dir():
     """Create staging directory for tests."""
     staging = Path(os.path.join(base_path, "staging"))
@@ -58,7 +58,7 @@ def testdata(chimecal_testfolder, chimestack_testfolder):
                 index_map.create_dataset("time", data=arr)
 
 
-@pytest.fixture("function")
+@pytest.fixture(scope="function")
 def reset_file_index():
     """Erase the file tracking index, so each test has a fresh one."""
     try:
@@ -104,3 +104,20 @@ def test_multiple_filetypes(reset_file_index, testdata, file_index):
 
     my_todo = client.new_files("test_analyzer_2", filetypes=["chimecal", "chimestack"])
     assert len(my_todo) == 10
+
+
+def test_time_filter(reset_file_index, testdata, file_index):
+    """Test new_files return of files intersecting within a timerange."""
+    client = Tracker("{0}/staging".format(base_path), file_index)
+
+    my_todo = client.new_files(
+        "test_analyzer_3", filetypes="chimecal", start=1593548300, end=1597551900
+    )
+
+    assert len(my_todo) == 10
+
+    my_todo = client.new_files(
+        "test_analyzer_3", filetypes="chimecal", start=1597551900
+    )
+
+    assert len(my_todo) == 0


### PR DESCRIPTION
- replace is a conflict resolution strategy that does not involve
force-inserting duplicates or IntegrityErrors
- conflicts result when multiple analyzers are trying to perform
updating actions to the same db simultaneously