### PR TITLE
Two bugfixes

### DIFF
--- a/dias/analyzers/dataset_analyzer.py
+++ b/dias/analyzers/dataset_analyzer.py
@@ -147,10 +147,9 @@ class DatasetAnalyzer(CHIMEAnalyzer):
 
             # Loop over acquisitions
             flag_tend = 0
+            flg = dict()
+            # Loop over contiguous periods within this acquisition
             for flag_acq, all_flag_files in flag_acqs.items():
-
-                # Loop over contiguous periods within this acquisition
-                flg = dict()
 
                 # Determine the range of time being processed
                 with h5py.File(all_flag_files[-1], "r") as final_file:

--- a/dias/analyzers/dataset_analyzer.py
+++ b/dias/analyzers/dataset_analyzer.py
@@ -174,8 +174,11 @@ class DatasetAnalyzer(CHIMEAnalyzer):
                     file_end = f["index_map/time"][-1]["ctime"]
 
                 if flag_tend < file_end:  # flag not available
-                    old = file_end < (
-                        datetime.datetime.utcnow() - datetime.timedelta(hours=24)
+                    old = (
+                        file_end
+                        < (
+                            datetime.datetime.utcnow() - datetime.timedelta(hours=24)
+                        ).timestamp()
                     )
 
                     if old:


### PR DESCRIPTION
The first bug came up when the tracker found multiple flaginput acquisitions within a timeframe.

It would only validating flags in the most recent acquisition, instead of in all of them, bc of me accidentally putting `flg = dict()` within the acquisition loop.
(This is the source of the new "Flag IDs not found" bug.)

The second bug was that Ia Unix timestamp float was being compared with a datetime object.