### PR TITLE
fix(chime_analyzer): Properly check for missing directory

### DIFF
--- a/dias/chime_analyzer.py
+++ b/dias/chime_analyzer.py
@@ -1,8 +1,8 @@
 """CHIME-specifc Analyzer Base Class."""
 
-import os
 from caput import config
 from dias import Analyzer
+from dias.utils import str2xpath
 from ch_util import finder
 
 
@@ -14,13 +14,8 @@ class CHIMEAnalyzer(Analyzer):
     CHIME-specific convenience methods.
     """
 
-    archive_data_dir = config.Property(proptype=str)
-    staging_data_dir = config.Property(proptype=str)
-
-    if not os.path.exists(archive_data_dir):
-        raise OSError("archive directory ({}) is missing".format(archive_data_dir))
-    if not os.path.exists(staging_data_dir):
-        raise OSError("staging directory ({}) is missing".format(staging_data_dir))
+    archive_data_dir = config.Property(proptype=str2xpath)
+    staging_data_dir = config.Property(proptype=str2xpath)
 
     def __init__(self, name, write_dir, state_dir, tracker):
         """Construct the CHIME analyzer base class.


### PR DESCRIPTION
I should have though a bit longer about that thing I thought was odd in the previous PR.

Those lines don't set the value; they just define the prototype for the Property.

Have deployed this.  It is running.