### PR TITLE
feat: remove feedpositions from being scheduled by dias

### DIFF
--- a/conf/tasks/feedpositions.conf
+++ b/conf/tasks/feedpositions.conf
@@ -1,6 +1,0 @@
-analyzer: "dias.analyzers.FeedpositionsAnalyzer"
-start_time: '2018-02-21 21:00:00'
-period: '24h'
-data_size_max: '1 GB'
-state_size_max: '0 B'
-sources: ['CAS_A', 'CYG_A', 'TAU_A', 'VIR_A']

--- a/dias/analyzers/feedpositions_analyzer.py
+++ b/dias/analyzers/feedpositions_analyzer.py
@@ -1,4 +1,8 @@
-"""A CHIME analyzer to calculate the East-West feed positions."""
+"""
+A CHIME analyzer to calculate the East-West feed positions.
+
+Note: This analyzer has been turned off since 2021-01-21.
+"""
 from dias import CHIMEAnalyzer, DiasConfigError
 from datetime import datetime, timedelta
 from caput import config, time


### PR DESCRIPTION
It is not considered useful anymore, and was starting to bug up a bit. We decided to not continue maintaining it.