### PR TITLE
fix(sensitivity): Fix `items` call in sensitivity analyser

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Install black
       run: pip install black
@@ -40,10 +40,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up python 3.8
+    - name: Set up python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Install apt dependencies
       run: |

--- a/dias/__init__.py
+++ b/dias/__init__.py
@@ -1,4 +1,5 @@
 """dias, a data integrity analysis system."""
+
 from .exception import DiasException, DiasUsageError, DiasConfigError
 from .exception import DiasConcurrencyError
 from .analyzer import Analyzer

--- a/dias/analyzer.py
+++ b/dias/analyzer.py
@@ -1,4 +1,5 @@
 """Analyzer Base Class."""
+
 import logging
 import os
 import re

--- a/dias/analyzers/__init__.py
+++ b/dias/analyzers/__init__.py
@@ -1,4 +1,5 @@
 """Analyzers for dias."""
+
 from .feedpositions_analyzer import FeedpositionsAnalyzer
 from .sample_analyzer import SampleAnalyzer
 from .test_analyzer import TestAnalyzer

--- a/dias/analyzers/daily_ringmaps.py
+++ b/dias/analyzers/daily_ringmaps.py
@@ -1,4 +1,5 @@
 """Analyzer to retrieve and store daily ringmaps."""
+
 import numpy as np
 import requests
 import msgpack

--- a/dias/analyzers/feedpositions_analyzer.py
+++ b/dias/analyzers/feedpositions_analyzer.py
@@ -3,6 +3,7 @@ A CHIME analyzer to calculate the East-West feed positions.
 
 Note: This analyzer has been turned off since 2021-01-21.
 """
+
 from dias import CHIMEAnalyzer, DiasConfigError
 from datetime import datetime, timedelta
 from caput import config, time

--- a/dias/analyzers/find_jump_analyzer.py
+++ b/dias/analyzers/find_jump_analyzer.py
@@ -21,6 +21,7 @@ Functions
     finger_finder
 
 """
+
 import os
 import time
 import datetime

--- a/dias/analyzers/flag_rfi_analyzer.py
+++ b/dias/analyzers/flag_rfi_analyzer.py
@@ -18,6 +18,7 @@ Functions
     :toctree: generated/
 
 """
+
 import os
 import time
 import datetime

--- a/dias/analyzers/sample_analyzer.py
+++ b/dias/analyzers/sample_analyzer.py
@@ -3,7 +3,6 @@
 This is a basic example for how to write an analyzer for dias.
 """
 
-
 from dias import CHIMEAnalyzer
 from datetime import datetime
 from caput import config

--- a/dias/analyzers/sensitivity_analyzer.py
+++ b/dias/analyzers/sensitivity_analyzer.py
@@ -243,9 +243,7 @@ class SensitivityAnalyzer(CHIMEAnalyzer):
                 ):
                     cnt[ss, :] += flag_ind[pp[0], :] * flag_ind[pp[1], :]
             else:
-                for ss, val in Counter(
-                    data.reverse_map["stack"]["stack"][:]
-                ).items():
+                for ss, val in Counter(data.reverse_map["stack"]["stack"][:]).items():
                     cnt[ss, :] = val
 
             # Initialize arrays

--- a/dias/analyzers/sensitivity_analyzer.py
+++ b/dias/analyzers/sensitivity_analyzer.py
@@ -245,7 +245,7 @@ class SensitivityAnalyzer(CHIMEAnalyzer):
             else:
                 for ss, val in Counter(
                     data.reverse_map["stack"]["stack"][:]
-                ).iteritems():
+                ).items():
                     cnt[ss, :] = val
 
             # Initialize arrays

--- a/dias/analyzers/test_analyzer.py
+++ b/dias/analyzers/test_analyzer.py
@@ -1,4 +1,5 @@
 """Analyzer to test the dias scheduler."""
+
 from dias import Analyzer
 from dias.utils import str2timedelta
 from time import sleep

--- a/dias/config_loader.py
+++ b/dias/config_loader.py
@@ -1,4 +1,5 @@
 """dias config loader."""
+
 import importlib
 import logging
 import yaml

--- a/dias/job.py
+++ b/dias/job.py
@@ -1,4 +1,5 @@
 """dias Job."""
+
 from dias import DiasConcurrencyError
 
 

--- a/dias/scheduler.py
+++ b/dias/scheduler.py
@@ -1,4 +1,5 @@
 """dias Scheduler."""
+
 import concurrent.futures
 import logging
 import threading

--- a/dias/task.py
+++ b/dias/task.py
@@ -1,4 +1,5 @@
 """dias Task."""
+
 import os
 import random
 import traceback

--- a/dias/task_queue.py
+++ b/dias/task_queue.py
@@ -1,4 +1,5 @@
 """dias task queue."""
+
 import threading
 
 

--- a/dias/utils/__init__.py
+++ b/dias/utils/__init__.py
@@ -1,4 +1,5 @@
 """Utilities for dias."""
+
 from .string_converter import *
 from .helpers import *
 from .tracker import *

--- a/dias/utils/string_converter.py
+++ b/dias/utils/string_converter.py
@@ -1,4 +1,5 @@
 """Helper functions to convert to and from strings."""
+
 from dias.exception import DiasException
 
 import os
@@ -42,7 +43,7 @@ def str2timedelta(time_str):
         return
     parts = parts.groupdict()
     time_params = {}
-    for (name, param) in parts.items():
+    for name, param in parts.items():
         if param:
             time_params[name] = int(param)
     if not time_params:


### PR DESCRIPTION
`sensitivity_analyzer.py` has the only substantive change.  It was still using `iteritems` instead of `items`, presumably in some code that's rarely exercised or we'd have found this earlier.

I've patched this in-place on marimba.

Also re-blackened.