### PR TITLE
fix(tracker): Skip locked files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,10 +40,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up python 3.9
+    - name: Set up python 3.10
       uses: actions/setup-python@v1
       with:
-        python-version: 3.9
+        python-version: "3.10"
 
     - name: Install apt dependencies
       run: |

--- a/dias/utils/tracker.py
+++ b/dias/utils/tracker.py
@@ -335,9 +335,13 @@ class Tracker:
 
         files_on_disk = []
         for ft in FILETYPES:
-            files_on_disk.extend(
-                glob.glob(os.path.join(self.base_path, "*_{0}".format(ft), "*.h5"))
-            )
+            for file_ in glob.glob(
+                os.path.join(self.base_path, "*_{0}".format(ft), "*.h5")
+            ):
+                # skip locked files
+                path = Path(file_)
+                if not Path(file_).with_name(f".{path.name}.lock").exists():
+                    files_on_disk.append(file_)
 
         files_in_db = [
             query.filepath for query in (File.select().where(File.exists == True))

--- a/test/test_tracker.py
+++ b/test/test_tracker.py
@@ -46,16 +46,20 @@ def testdata(chimecal_testfolder, chimestack_testfolder):
     """Create all of the testdata."""
     for folder in [chimecal_testfolder, chimestack_testfolder]:
         Path(folder).mkdir(exist_ok=True)
-        for i in range(10):
+        for i in range(20):
             with h5py.File("{0}/sample_{1}.h5".format(folder, i), "w") as hf:
                 index_map = hf.create_group("index_map")
 
                 arr = np.rec.fromarrays(
                     [np.arange(1596549345.2508698, 1596551880.0784922)],
-                    dtype=np.dtype({"names": ["ctime"], "formats": [(float)]}),
+                    dtype=np.dtype({"names": ["ctime"], "formats": [float]}),
                 )
 
                 index_map.create_dataset("time", data=arr)
+
+        # Lock some of the files
+        for i in range(10):
+            open(f"{folder}/.sample_{i+10}.h5.lock", "w").close()
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
Such files will be completely skipped by the tracker, as if they didn't exist on disk.

Locked files are ones for which a .<name>.lock file exists.