### PR TITLE
fix(flag_rfi): Don't give finder invalid interval

### DIFF
--- a/dias/analyzers/flag_rfi_analyzer.py
+++ b/dias/analyzers/flag_rfi_analyzer.py
@@ -336,6 +336,13 @@ class FlagRFIAnalyzer(chime_analyzer.CHIMEAnalyzer):
         results = list(cursor.execute(query))
         start_time = results[0][0] if results else end_time - self.period
 
+        # Check for sensible time range
+        if start_time >= end_time:
+            self.logger.warning(
+                f"Non-positive time range: {datetime2str(start_time)} to {datetime2str(end_time)}"
+            )
+            return
+
         self.logger.info(
             "Analyzing data between {} and {}.".format(
                 datetime2str(start_time), datetime2str(end_time)


### PR DESCRIPTION
The Finder crashes with a ValueError when given a non-positive time range.